### PR TITLE
Using PackageLicenseExpression in .csproj file

### DIFF
--- a/Zip/Zip.csproj
+++ b/Zip/Zip.csproj
@@ -15,8 +15,7 @@
     <Version>2025.02.15</Version>
     <Authors>Dino Chiesa</Authors>
     <Company>Dino Chiesa</Company>
-
-    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 


### PR DESCRIPTION
In "https://www.nuget.org/packages/DotNetZip.Original" the License Info should be as "Apache-2.0 Lincense".

Example: https://www.nuget.org/packages/Serilog/4.2.1-dev-02352